### PR TITLE
Modify cfg and readme for running bot from repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Python module for the Willie IRC bot used in the Handmade Hero twitch chat.
 
 Custom commands are defined in `handmade.py`, `handmade_faq.py`, `handmade_stream.py`, and `handmade_bonus.py`. `handmade.py` should be reserved commands related to the bot functionality, `handmade_faq.py` for common stream questions, `handmade_stream.py` for stream scheduling and timing based functions, and `handmade_bonus.py` for easter eggs and miscellaneous commands.
 
-The config options used by the bot are available in `default.cfg`. Please refer to the [Willie documentation](http://willie.dftba.net/) for what the common configuration options mean.
+The config options used by the bot are available in `handmade.cfg`. Please refer to the [Willie documentation](http://willie.dftba.net/) for what the common configuration options mean.
 
 `test.py` is currently deprecated, it might be useful at some point in the future to attempt to set up a series of tests to run to ensure the bot remains working.
 
@@ -13,17 +13,19 @@ Please refer to the [forum thread](https://forums.handmadehero.org/index.php/for
 
 Installation
 ----
-Copy the contents of this repo to your ~/.willie folder (`/home/user/.willie` on linux, `C:/Users/user/.willie` on windows)
+Clone the repository and cd into the directory.
 
-Then run `willie` to start the bot.
+Then run `willie -c handmade.cfg` to start the bot.
 
 Important: Please make sure that there is not already an instance of ChronalRobot running in chat. Twitch will not prevent multiple of them from running at a time, and all active instances will attempt to respond to queries. An easy way to test for this is to use the **!hello** command, as this should always be available. (Note: as of recently, the default bot username is now **hmh_bot**. You can run your own instance alongside if you change the username, oauth, and command character for the bot.)
 
 Libraries
 ---
-Robot requires the following libraries to be installed: pytz and parsedatetime
+Robot requires the following libraries to be installed: willie, pytz, and parsedatetime
 
 To install them, issue following commands:
+
+sudo pip install willie
 
 sudo pip install pytz
 

--- a/handmade.cfg
+++ b/handmade.cfg
@@ -8,6 +8,7 @@ owner = chronaldragon
 channels = #handmade_hero,#chronalrobot
 server_password = oauth:lua84kyya3g3iiyal9ww1nvvl4sbpn
 prefix = \!
+extra = ./modules
 exclude = meetbot,clock,bugzilla,rss,ipython,reddit,currency,weather,ip,spellcheck,youtube
 enable= handmade,handmade_stream,handmade_faq,handmade_bonus,xkcd,uptime
 admins=abnercoimbre,garlandobloom,drive137
@@ -16,7 +17,7 @@ debug_target=stdio
 
 [db]
 userdb_type = sqlite
-userdb_file = ~/.willie/handmade.db
+userdb_file = ./handmade.db
 
 [wikipedia]
 default_lang = en
@@ -26,7 +27,7 @@ tz = PST
 time_format = %T%Z, %F
 
 [chanlogs]
-dir = ~/.willie/logs
+dir = ./logs
 by_day = True
 privmsg = False
 microseconds = False


### PR DESCRIPTION
This is a simple modification that allows you to run the bot from where you checked out instead of having to modify the default willie config and mix the repository modules with the default willie modules.
There are some changes of names and associated changes to the readme to reflect this.