### PR TITLE
'time' command is now just an alias for 'timer'

### DIFF
--- a/modules/handmade_faq.py
+++ b/modules/handmade_faq.py
@@ -37,7 +37,7 @@ def msdnSearch(bot, trigger):
         query = trigger.group(2).strip()
         bot.say("@%s: %s" % (trigger.nick, google(query)))
 
-@command('time', 'now', 'pst', 'PST')
+@command('now', 'pst', 'PST')
 def getTime(bot, trigger):
     """Info command that prints out the current time in PST. For the purposes of the handmade hero
         stream, we don't really care about other time zones.

--- a/modules/handmade_stream.py
+++ b/modules/handmade_stream.py
@@ -161,7 +161,7 @@ def isStreamingCommand(bot, trigger):
 		bot.say("Stream is not currently going.")
 
 
-@command('timer', "when", "howlong", "timeleft")
+@command("time", "timer", "when", "howlong", "timeleft")
 def timer(bot, trigger):
 	"""Info command that prints out the time until the next stream.
 	"""


### PR DESCRIPTION
People did not find !time particularly useful. Make it an alias for !timer instead.