### PR TITLE
Fixing whitelisted_streamtime documentation

### DIFF
--- a/modules/handmade.py
+++ b/modules/handmade.py
@@ -96,7 +96,7 @@ def adminonly_streamtime(func):
     return wrapperFunc
 
 def whitelisted_streamtime(func):
-    """Decorator that only allows the function to run if the caller is an admin or owner if the
+    """Decorator that only allows the function to run if the caller is whitelisted if the
        stream is currently on.
     """
     @functools.wraps(func)


### PR DESCRIPTION
The documentation for the `whitelisted_streamtime` wrapper had the same documentation as the `adminonly_streamtime` documentation. Changed it to be relevant to whitelist.