### PR TITLE
Add cooldown functionality to FAQ commands

### DIFF
--- a/modules/handmade_bonus.py
+++ b/modules/handmade_bonus.py
@@ -79,7 +79,7 @@ def whyInfo(bot, trigger):
 def randomNumber(bot, trigger):
     """Easter egg info command that returns a randomly-selected number.
     """
-    info(bot, trigger, "Your random number is %s" % (random.randint(100) if random.random() < 0.0001 else 4))
+    info(bot, trigger, "Your random number is %s" % (random.randint(100) if random.random() < 0.001 else 4))
 
 @adminonly_streamtime
 @command('roll', hide=True)
@@ -89,17 +89,27 @@ def rollNumber(bot, trigger):
         output = ""
         for arg in args:
             diceArgs = arg.split("d")
-            diceAmt = diceArgs[0]
-            try:
-                diceAmt = int(diceAmt)
-            except ValueError:
-                bot.say("@%s: I can't roll %s dice" % (trigger.nick, diceAmt))
+
+            if (len(diceArgs) > 0):
+                diceAmt = diceArgs[0]
+                try:
+                    diceAmt = int(diceAmt)
+                except ValueError:
+                    bot.say("@%s: I can't roll %s dice" % (trigger.nick, diceAmt))
+                    return
+            else:
+                bot.say("@%s: Wait, how many dice is that?" % trigger.nick)
                 return
-            diceFaces = diceArgs[1]
-            try:
-                diceFaces = int(diceFaces)
-            except ValueError:
-                bot.say("@%s: I can't roll dice with %s faces!" % (trigger.nick, diceFaces))
+
+            if (len(diceArgs) > 1):
+                diceFaces = diceArgs[1]
+                try:
+                    diceFaces = int(diceFaces)
+                except ValueError:
+                    bot.say("@%s: I can't roll dice with %s faces!" % (trigger.nick, diceFaces))
+                    return
+            else:
+                bot.say("@%s: Wait, how many faces is that?" % trigger.nick)
                 return
 
             if (diceAmt < 0):


### PR DESCRIPTION
Note: this can be applied to any command registered using the @command decorator by passing "cooldown=##" where ## is a number of seconds for cooldown to last. All the FAQ functions were given a cooldown of 10 seconds, during which time the bot will simply say "see above" instead of the full text.